### PR TITLE
Design change separate filters api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,17 @@ from cowin_api import CoWinAPI
 
 district_id = '395'
 date = '03-05-2021'  # Optional. Takes today's date by default
-min_age_limit = 18  # Optional. By default returns centers without filtering by min_age_limit
+min_age_limit = 18  # Optional int. By default returns centers without filtering by min_age_limit
+min_capacity = None  # Optional int. By default returns centers without filtering by min_capacity
+vaccine = None  # Optional str. By default returns centers without filtering by vaccine
+fee_type = None  # Optional str. By default returns centers without filtering by fee_type
 
 cowin = CoWinAPI()
 available_centers = cowin.get_availability_by_district(district_id, date, min_age_limit)
+# available_centers = cowin.get_availability_by_district(district_id, min_age_limit=18,
+                                                         # min_capacity=1,
+                                                         # vaccine='COVAXIN',
+                                                         # fee_type='Free')
 print(available_centers)
 ```
 
@@ -197,10 +204,16 @@ from cowin_api import CoWinAPI
 
 pin_code = "400080"
 date = '03-05-2021'  # Optional. Default value is today's date
-min_age_limit = 18  # Optional. By default returns centers without filtering by min_age_limit
-
+min_age_limit = 18  # Optional int. By default returns centers without filtering by min_age_limit
+min_capacity = None  # Optional int. By default returns centers without filtering by min_capacity
+vaccine = None  # Optional str. By default returns centers without filtering by vaccine
+fee_type = None  # Optional str. By default returns centers without filtering by fee_type
 cowin = CoWinAPI()
 available_centers = cowin.get_availability_by_pincode(pin_code, date, min_age_limit)
+# available_centers = cowin.get_availability_by_pincode(district_id, min_age_limit=18,
+                                                        # min_capacity=1,
+                                                        # vaccine='COVAXIN',
+                                                        # fee_type='Free')
 print(available_centers)
 ```
 
@@ -332,7 +345,7 @@ fixed interval
 - [x] Allow user to search for multiple districts
 - [ ] Catch and raise custom exceptions
 - [ ] Implement Rate Limiting
-- [ ] Implement mocking in test cases
+- [x] Implement mocking in test cases
 
 ---
 

--- a/cowin_api/api.py
+++ b/cowin_api/api.py
@@ -2,7 +2,7 @@ from typing import Union, List
 
 from cowin_api.base_api import BaseApi
 from cowin_api.constants import Constants
-from cowin_api.utils import today, filter_centers_by_age_limit
+from cowin_api.utils import today, filter_centers
 
 
 class CoWinAPI(BaseApi):
@@ -17,7 +17,10 @@ class CoWinAPI(BaseApi):
 
     def get_availability_by_base(self, caller: str,
                                  areas: Union[str, List[str]],
-                                 date: str, min_age_limt: int):
+                                 date: str, min_age_limit: int,
+                                 min_capacity: int,
+                                 vaccine: str,
+                                 fee_type: str):
         """this function is called by the get availability function
         this is separated out so that the parent functions have the same
         structure and development becomes easier"""
@@ -27,30 +30,51 @@ class CoWinAPI(BaseApi):
         # if the areas is a str, convert to list
         if isinstance(areas, str):
             areas = [areas]
-        # make a separate call for each of the areas
+
+        # make a separate call for each of the areas, first get all the
+        # results and then apply the filters
         results = []
         for area_id in areas:
             url = f"{base_url}?{area_type}={area_id}&date={date}"
-            if min_age_limt:
-                curr_result = filter_centers_by_age_limit(self._call_api(url),
-                                                          min_age_limt)
-            else:
-                curr_result = self._call_api(url)
+            curr_result = self._call_api(url)
             # append
             if curr_result:
-                results += curr_result['centers']
+                results += curr_result.get('centers')
+
+        results = {'centers': results}
+
+        # apply the filters
+        # the change from min_capacity to available_capacity is requried
+        # to keep consistency with columns names of results from api
+        results = filter_centers(results,
+                                 ['min_age_limit', 'available_capacity',
+                                  'vaccine', 'fee_type'],
+                                 [min_age_limit, min_capacity,
+                                  vaccine, fee_type])
 
         # return the results in the same format as returned by the api
-        return {'centers': results}
+        return results
 
     def get_availability_by_district(self, district_id: Union[str, List[str]],
                                      date: str = today(),
-                                     min_age_limt: int = None):
+                                     min_age_limit: int = None,
+                                     min_capacity: int = None,
+                                     vaccine: str = None,
+                                     fee_type: str = None):
         return self.get_availability_by_base(caller='district', areas=district_id,
-                                             date=date, min_age_limt=min_age_limt)
+                                             date=date, min_age_limit=min_age_limit,
+                                             min_capacity=min_capacity,
+                                             vaccine=vaccine,
+                                             fee_type=fee_type)
 
     def get_availability_by_pincode(self, pin_code: Union[str, List[str]],
                                     date: str = today(),
-                                    min_age_limt: int = None):
+                                    min_age_limit: int = None,
+                                     min_capacity: int = None,
+                                     vaccine: str = None,
+                                     fee_type: str = None):
         return self.get_availability_by_base(caller='pincode', areas=pin_code,
-                                             date=date, min_age_limt=min_age_limt)
+                                             date=date, min_age_limit=min_age_limit,
+                                             min_capacity=min_capacity,
+                                             vaccine=vaccine,
+                                             fee_type=fee_type)

--- a/cowin_api/api.py
+++ b/cowin_api/api.py
@@ -17,10 +17,11 @@ class CoWinAPI(BaseApi):
 
     def get_availability_by_base(self, caller: str,
                                  areas: Union[str, List[str]],
-                                 date: str, min_age_limit: int,
+                                 date: str,
+                                 min_age_limit: Union[int, List[int]],
                                  min_capacity: int,
-                                 vaccine: str,
-                                 fee_type: str):
+                                 vaccine: Union[str, List[str]],
+                                 fee_type: Union[str, List[str]]):
         """this function is called by the get availability function
         this is separated out so that the parent functions have the same
         structure and development becomes easier"""
@@ -59,10 +60,10 @@ class CoWinAPI(BaseApi):
 
     def get_availability_by_district(self, district_id: Union[str, List[str]],
                                      date: str = today(),
-                                     min_age_limit: int = None,
+                                     min_age_limit: Union[int, List[int]] = None,
                                      min_capacity: int = None,
-                                     vaccine: str = None,
-                                     fee_type: str = None):
+                                     vaccine: Union[str, List[str]] = None,
+                                     fee_type: Union[str, List[str]] = None):
         return self.get_availability_by_base(caller='district', areas=district_id,
                                              date=date, min_age_limit=min_age_limit,
                                              min_capacity=min_capacity,
@@ -71,10 +72,10 @@ class CoWinAPI(BaseApi):
 
     def get_availability_by_pincode(self, pin_code: Union[str, List[str]],
                                     date: str = today(),
-                                    min_age_limit: int = None,
-                                     min_capacity: int = None,
-                                     vaccine: str = None,
-                                     fee_type: str = None):
+                                    min_age_limit: Union[int, List[int]] = None,
+                                    min_capacity: int = None,
+                                    vaccine: Union[str, List[str]] = None,
+                                    fee_type: Union[str, List[str]] = None):
         return self.get_availability_by_base(caller='pincode', areas=pin_code,
                                              date=date, min_age_limit=min_age_limit,
                                              min_capacity=min_capacity,

--- a/cowin_api/api.py
+++ b/cowin_api/api.py
@@ -46,11 +46,13 @@ class CoWinAPI(BaseApi):
         # apply the filters
         # the change from min_capacity to available_capacity is requried
         # to keep consistency with columns names of results from api
-        results = filter_centers(results,
-                                 ['min_age_limit', 'available_capacity',
-                                  'vaccine', 'fee_type'],
-                                 [min_age_limit, min_capacity,
-                                  vaccine, fee_type])
+        filter_dict = {
+            'min_age_limit': min_age_limit,
+            'available_capacity': min_capacity,
+            'vaccine': vaccine,
+            'fee_type': fee_type
+        }
+        results = filter_centers(results, filter_dict)
 
         # return the results in the same format as returned by the api
         return results

--- a/cowin_api/constants.py
+++ b/cowin_api/constants.py
@@ -8,31 +8,3 @@ class Constants:
     availability_by_district_url = f"{base_url}/appointment/sessions/public/calendarByDistrict"
 
     DD_MM_YYYY = "%d-%m-%Y"
-
-    """a dictionary to store which columns appear at which level in the
-    returned results to help with the looping"""
-    col_to_loop_level = {
-        'min_age_limit': 2,
-        'available_capacity': 2,
-        'vaccine': 2,
-        'fee_type': 1,
-    }
-
-    """a dictionary to store the data types of the various columns in
-    the returned results to help with assertion checks"""
-    col_to_data_type = {
-        'min_age_limit': int,
-        'available_capacity': int,
-        'vaccine': str,
-        'fee_type': str,
-    }
-
-    """a dictionary to store the comparison types of the various columns in
-    the returned results x is from the data while y is the filter value
-    passed to filter_centers"""
-    col_to_comparison = {
-        'min_age_limit': lambda x, y: True if x == y else False,
-        'available_capacity': lambda x, y: True if x >= y else False,
-        'vaccine': lambda x, y: True if x.upper() == y.upper() else False,
-        'fee_type': lambda x, y: True if x.upper() == y.upper() else False,
-    }

--- a/cowin_api/constants.py
+++ b/cowin_api/constants.py
@@ -8,3 +8,31 @@ class Constants:
     availability_by_district_url = f"{base_url}/appointment/sessions/public/calendarByDistrict"
 
     DD_MM_YYYY = "%d-%m-%Y"
+
+    """a dictionary to store which columns appear at which level in the
+    returned results to help with the looping"""
+    col_to_loop_level = {
+        'min_age_limit': 2,
+        'available_capacity': 2,
+        'vaccine': 2,
+        'fee_type': 1,
+    }
+
+    """a dictionary to store the data types of the various columns in
+    the returned results to help with assertion checks"""
+    col_to_data_type = {
+        'min_age_limit': int,
+        'available_capacity': int,
+        'vaccine': str,
+        'fee_type': str,
+    }
+
+    """a dictionary to store the comparison types of the various columns in
+    the returned results x is from the data while y is the filter value
+    passed to filter_centers"""
+    col_to_comparison = {
+        'min_age_limit': lambda x, y: True if x == y else False,
+        'available_capacity': lambda x, y: True if x >= y else False,
+        'vaccine': lambda x, y: True if x == y else False,
+        'fee_type': lambda x, y: True if x == y else False,
+    }

--- a/cowin_api/constants.py
+++ b/cowin_api/constants.py
@@ -33,6 +33,6 @@ class Constants:
     col_to_comparison = {
         'min_age_limit': lambda x, y: True if x == y else False,
         'available_capacity': lambda x, y: True if x >= y else False,
-        'vaccine': lambda x, y: True if x == y else False,
-        'fee_type': lambda x, y: True if x == y else False,
+        'vaccine': lambda x, y: True if x.upper() == y.upper() else False,
+        'fee_type': lambda x, y: True if x.upper() == y.upper() else False,
     }

--- a/cowin_api/utils.py
+++ b/cowin_api/utils.py
@@ -9,32 +9,23 @@ def today() -> str:
     return datetime.now().strftime(Constants.DD_MM_YYYY)
 
 
-def filter_centers(centers: dict, filter_col: List[str],
-                   filter_val: List[Union[str, int]]):
+def filter_centers(centers: dict, filters: dict):
     """A common function to apply filter at the second level of looping
     in the results returned by the api, we will do an assertion test of the
     data type for compatibility between filter col and filter val"""
 
     # any filter cols with None values should be ignored
-    # first get the indices with non none values
-    non_none_indices = set([index for index, val in enumerate(filter_val)\
-                        if val is not None])
-    # filter out the cols
-    filter_col = [val for index, val in enumerate(filter_col)\
-                   if index in non_none_indices]
-    # filter out the values
-    filter_val = [val for index, val in enumerate(filter_val)\
-                   if index in non_none_indices]
+    filters = {k:v for k, v in filters.items() if v is not None}
 
     # if no filters, return as is
-    if len(filter_col) == 0:
+    if not filters:
         return centers
 
     # first checks if the filter val are compatible with filter cols
-    for index, col in enumerate(filter_col):
-        assert isinstance(filter_val[index], Constants.col_to_data_type[col]),\
-        f"[DATA TYPE INCOMPATIBLE] for filter {col}, expected instance of \
-        {Constants.col_to_data_type[col]}, got {type(filter_val[index])}"
+    for f_key in filters:
+        assert isinstance(filters[f_key], Constants.col_to_data_type[f_key]),\
+        f"[DATA TYPE INCOMPATIBLE] for filter {f_key}, expected instance of \
+        {Constants.col_to_data_type[f_key]}, got {type(filters[f_key])}"
 
     original_centers = centers.get('centers')
     # this stores the results to be returned
@@ -46,19 +37,19 @@ def filter_centers(centers: dict, filter_col: List[str],
         # iterate over the columns for any level 1 filter, if the filter
         # is passed, only then continue with the below
         keep_this_center = True
-        for index, col in enumerate(filter_col):
-            if Constants.col_to_loop_level[col] == 1:
-                if isinstance(filter_val[index], str):
+        for f_key in filters:
+            if Constants.col_to_loop_level[f_key] == 1:
+                if isinstance(filters[f_key], str):
                     # make the check case insensitive
-                    if not Constants.col_to_comparison[col](center.get(col).upper(),
-                                                            filter_val[index].upper()):
+                    if not Constants.col_to_comparison[f_key](center.get(f_key).upper(),
+                                                              filters[f_key].upper()):
                         # go to the next center
                         keep_this_center = False
                         break
                 else:
                     # normal comparison
-                    if not Constants.col_to_comparison[col](center.get(col),
-                                                            filter_val[index]):
+                    if not Constants.col_to_comparison[f_key](center.get(f_key),
+                                                              filters[f_key]):
                         # go to the next center
                         keep_this_center = False
                         break
@@ -72,18 +63,18 @@ def filter_centers(centers: dict, filter_col: List[str],
             keep_this_session = True
 
             # iterate over the columns and check for filters
-            for index, col in enumerate(filter_col):
-                if Constants.col_to_loop_level[col] == 2:
-                    if isinstance(filter_val[index], str):
+            for f_key in filters:
+                if Constants.col_to_loop_level[f_key] == 2:
+                    if isinstance(filters[f_key], str):
                         # make the check case insensitive
-                        if not Constants.col_to_comparison[col](session.get(col).upper(),
-                                                                filter_val[index].upper()):
+                        if not Constants.col_to_comparison[f_key](session.get(f_key).upper(),
+                                                                  filters[f_key].upper()):
                             keep_this_session = False
                             break
                     else:
                         # normal comparison
-                        if not Constants.col_to_comparison[col](session.get(col),
-                                                                filter_val[index]):
+                        if not Constants.col_to_comparison[f_key](session.get(f_key),
+                                                                  filters[f_key]):
                             keep_this_session = False
                             break
 

--- a/cowin_api/utils.py
+++ b/cowin_api/utils.py
@@ -1,3 +1,5 @@
+from typing import Union, List
+
 from datetime import datetime
 
 from cowin_api.constants import Constants
@@ -7,14 +9,92 @@ def today() -> str:
     return datetime.now().strftime(Constants.DD_MM_YYYY)
 
 
-def filter_centers_by_age_limit(centers: dict, min_age_limit: int):
+def filter_centers(centers: dict, filter_col: List[str],
+                   filter_val: List[Union[str, int]]):
+    """A common function to apply filter at the second level of looping
+    in the results returned by the api, we will do an assertion test of the
+    data type for compatibility between filter col and filter val"""
+
+    # any filter cols with None values should be ignored
+    # first get the indices with non none values
+    non_none_indices = set([index for index, val in enumerate(filter_val)\
+                        if val is not None])
+    # filter out the cols
+    filter_col = [val for index, val in enumerate(filter_col)\
+                   if index in non_none_indices]
+    # filter out the values
+    filter_val = [val for index, val in enumerate(filter_val)\
+                   if index in non_none_indices]
+
+    # if no filters, return as is
+    if len(filter_col) == 0:
+        return centers
+
+    # first checks if the filter val are compatible with filter cols
+    for index, col in enumerate(filter_col):
+        assert isinstance(filter_val[index], Constants.col_to_data_type[col]),\
+        f"[DATA TYPE INCOMPATIBLE] for filter {col}, expected instance of \
+        {Constants.col_to_data_type[col]}, got {type(filter_val[index])}"
+
     original_centers = centers.get('centers')
+    # this stores the results to be returned
     filtered_centers = {'centers': []}
-    for index, center in enumerate(original_centers):
+    # level 1 loop
+    for center in original_centers:
         filtered_sessions = []
+
+        # iterate over the columns for any level 1 filter, if the filter
+        # is passed, only then continue with the below
+        keep_this_center = True
+        for index, col in enumerate(filter_col):
+            if Constants.col_to_loop_level[col] == 1:
+                if isinstance(filter_val[index], str):
+                    # make the check case insensitive
+                    if not Constants.col_to_comparison[col](center.get(col).upper(),
+                                                            filter_val[index].upper()):
+                        # go to the next center
+                        keep_this_center = False
+                        break
+                else:
+                    # normal comparison
+                    if not Constants.col_to_comparison[col](center.get(col),
+                                                            filter_val[index]):
+                        # go to the next center
+                        keep_this_center = False
+                        break
+
+        # go to the next center
+        if not keep_this_center:
+            continue
+
+        # level 2 loop
         for session in center.get('sessions'):
-            if session.get('min_age_limit') == min_age_limit:
-                filtered_sessions.append(session)
+            keep_this_session = True
+
+            # iterate over the columns and check for filters
+            for index, col in enumerate(filter_col):
+                if Constants.col_to_loop_level[col] == 2:
+                    if isinstance(filter_val[index], str):
+                        # make the check case insensitive
+                        if not Constants.col_to_comparison[col](session.get(col).upper(),
+                                                                filter_val[index].upper()):
+                            keep_this_session = False
+                            break
+                    else:
+                        # normal comparison
+                        if not Constants.col_to_comparison[col](session.get(col),
+                                                                filter_val[index]):
+                            keep_this_session = False
+                            break
+
+            # go to the next session
+            if not keep_this_session:
+                continue
+
+            # if we have reached this point, the session can be appended
+            filtered_sessions.append(session)
+
+        # checked if anything got filtered
         if len(filtered_sessions) > 0:
             center['sessions'] = filtered_sessions
             filtered_centers['centers'].append(center)

--- a/cowin_api/utils.py
+++ b/cowin_api/utils.py
@@ -39,20 +39,12 @@ def filter_centers(centers: dict, filters: dict):
         keep_this_center = True
         for f_key in filters:
             if Constants.col_to_loop_level[f_key] == 1:
-                if isinstance(filters[f_key], str):
-                    # make the check case insensitive
-                    if not Constants.col_to_comparison[f_key](center.get(f_key).upper(),
-                                                              filters[f_key].upper()):
-                        # go to the next center
-                        keep_this_center = False
-                        break
-                else:
-                    # normal comparison
-                    if not Constants.col_to_comparison[f_key](center.get(f_key),
-                                                              filters[f_key]):
-                        # go to the next center
-                        keep_this_center = False
-                        break
+                # make the check case insensitive: now done inside constants
+                if not Constants.col_to_comparison[f_key](center.get(f_key),
+                                                          filters[f_key]):
+                    # go to the next center
+                    keep_this_center = False
+                    break
 
         # go to the next center
         if not keep_this_center:
@@ -65,18 +57,11 @@ def filter_centers(centers: dict, filters: dict):
             # iterate over the columns and check for filters
             for f_key in filters:
                 if Constants.col_to_loop_level[f_key] == 2:
-                    if isinstance(filters[f_key], str):
-                        # make the check case insensitive
-                        if not Constants.col_to_comparison[f_key](session.get(f_key).upper(),
-                                                                  filters[f_key].upper()):
-                            keep_this_session = False
-                            break
-                    else:
-                        # normal comparison
-                        if not Constants.col_to_comparison[f_key](session.get(f_key),
-                                                                  filters[f_key]):
-                            keep_this_session = False
-                            break
+                    # make the check case insensitive: now done inside constants
+                    if not Constants.col_to_comparison[f_key](session.get(f_key),
+                                                              filters[f_key]):
+                        keep_this_session = False
+                        break
 
             # go to the next session
             if not keep_this_session:

--- a/tests/sample_response_for_testing.json
+++ b/tests/sample_response_for_testing.json
@@ -1,0 +1,1069 @@
+// https://cdn-api.co-vin.in/api/v2/appointment/sessions/public/calendarByDistrict?district_id=512&date=08-05-2021
+// data obtained at around 1800 hrs on 08-05-2021
+{
+    "centers": [{
+        "center_id": 551487,
+        "name": "UPHC Jaggannath Mandir 18-44",
+        "address": "Jaggannath Mandir UPHC",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "81aee02b-f72e-4f25-b2c3-ca85ea0dd68f",
+            "date": "08-05-2021",
+            "available_capacity": 13,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 693609,
+        "name": "Jain Bhawan Hasan Khan Mewati",
+        "address": "Akhil Bhartiya Palliwal Jain Mahasabha Bhawan Alwar",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "251d2ade-7b04-4191-9340-f3a776469d39",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 578497,
+        "name": "45 Phc Badaka Block Laxmangarh",
+        "address": "Phc Badaka",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Laxmangarh",
+        "pincode": 321607,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "0b0a1cbe-b085-4487-b7fa-1b76fb785016",
+            "date": "08-05-2021",
+            "available_capacity": 46,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 338773,
+        "name": "45 GUDACHURANI PHC THANAGAZI",
+        "address": "Gudhachurani Phc",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Thanagazi",
+        "pincode": 301022,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "3a4db774-ed50-4033-a2be-6abea2dc46d1",
+            "date": "08-05-2021",
+            "available_capacity": 46,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 568351,
+        "name": "Kalakaun Satellite Above 45",
+        "address": "Kalakaunalwar",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "fc7d39b4-1159-426e-b2c0-ce5d216def1a",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 693502,
+        "name": "Samudayik Bhawan Kalakuan",
+        "address": "Kalakuan",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 0,
+        "long": 0,
+        "from": "09:30:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "1feeb2af-0f4c-41aa-abcf-02fb025dc239",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:30AM-10:30AM", "10:30AM-11:30AM", "11:30AM-12:30PM", "12:30PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 575472,
+        "name": "45 PHC BILETA BLOCK RENI",
+        "address": "PHC BILETA BLOCK RENI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Reni",
+        "pincode": 301414,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "1f349016-0a1e-4e38-95e4-8694f5fe3497",
+            "date": "08-05-2021",
+            "available_capacity": 8,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 338728,
+        "name": "PHC JAMDOLI BLOCK RENI",
+        "address": "PHC JAMDOLI BLOCK RENI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Reni",
+        "pincode": 301409,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "725b6e0a-730a-4f67-8932-4545c42ed7aa",
+            "date": "08-05-2021",
+            "available_capacity": 8,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 335133,
+        "name": "45 CHC NARAYANPUR",
+        "address": "CHC NARAYANPUR",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Thanagazi",
+        "pincode": 301024,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "2af96de8-9e50-4884-a1e6-a59d9f99822a",
+            "date": "08-05-2021",
+            "available_capacity": 72,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 575546,
+        "name": "45 PL KAYSA PHC SHAJAPUR",
+        "address": "KAYSA PHC",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Shahjahanpur",
+        "pincode": 301703,
+        "lat": 28,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "b4b3cec7-5692-46e6-88b7-d55b19d73d95",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 532717,
+        "name": "PHC DEHRA",
+        "address": "PHC DEHRA",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Malakhera",
+        "pincode": 301409,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "742c2bde-36e6-46ee-8fb3-f355184106be",
+            "date": "08-05-2021",
+            "available_capacity": 50,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 532644,
+        "name": "Karoli PHC",
+        "address": "Karoli PHC",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Tijara",
+        "pincode": 301028,
+        "lat": 28,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "96be42dd-8b13-453e-86ab-db55d8ae406e",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 334183,
+        "name": "CHC PINAN BLOCK RENI",
+        "address": "CHC PINAN BLOCK RENI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Reni",
+        "pincode": 301409,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "14771c96-51ad-41d1-a17c-6b8c0445b8a0",
+            "date": "08-05-2021",
+            "available_capacity": 9,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 666785,
+        "name": "Railway Dispensary",
+        "address": "Railway Dispensary",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 0,
+        "long": 0,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "30d4259a-07af-4a47-8195-6c0fee2b36a0",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }, {
+            "session_id": "9b4e034c-4e21-4dce-b85c-4d477e6e5297",
+            "date": "11-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 581644,
+        "name": "UPHC Shivaji Park Above 45",
+        "address": "Shivaji Park",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "38ad418b-f595-46c0-a632-2ae94b2d99da",
+            "date": "08-05-2021",
+            "available_capacity": 1,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }, {
+            "session_id": "63579f59-9001-4735-8cd9-58430ec00df7",
+            "date": "09-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }, {
+            "session_id": "657f8ebb-b3f2-4215-b387-b5dbd3182331",
+            "date": "10-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 551508,
+        "name": "45 PHC MACHEDI BLOCK RENI",
+        "address": "PHC Machedi BLOCK RENI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Reni",
+        "pincode": 301409,
+        "lat": 0,
+        "long": 0,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "4b64af7e-dcc8-4e80-a5e2-c893828ff7a1",
+            "date": "08-05-2021",
+            "available_capacity": 3,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 532103,
+        "name": "Jatiyana Sc Harsoli Chc Kot",
+        "address": "Jatiyana",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "baheror",
+        "pincode": 301702,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "3aedf8b3-0b4d-4015-baf7-68e6d6d07e48",
+            "date": "08-05-2021",
+            "available_capacity": 49,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 338615,
+        "name": "GOVT SCHOOL Hodayali RAJGARH",
+        "address": "GOVT SCHOOL HODAYALI DIGAWERA PHC RAJGARH",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Rajgarh",
+        "pincode": 301408,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "5f34232b-70ff-41b7-b112-89c04fb0344f",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 573498,
+        "name": "Nikach PHC",
+        "address": "Nikach PHC",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Ramgarh",
+        "pincode": 301025,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "a1eb39a5-ac96-4b67-9927-472b9d775140",
+            "date": "08-05-2021",
+            "available_capacity": 100,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 581843,
+        "name": "UPHC AKHEPURA Above 45",
+        "address": "UPHC AKHEPURA CHAMELI BAGH BHOLE NATH KI BAGICHI K SAMNE ALWAR",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "b3378834-0d0f-4f5f-9918-cdf1f2ccadd5",
+            "date": "08-05-2021",
+            "available_capacity": 38,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 571814,
+        "name": "Mubarikapur PHC",
+        "address": "Mubarikapur PHC",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Ramgarh",
+        "pincode": 301025,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "7c45a232-7dad-446c-bee8-7b48c4a04c9e",
+            "date": "08-05-2021",
+            "available_capacity": 150,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 335077,
+        "name": "45 CHC RENI BLOCK RENI",
+        "address": "CHC RENI BLOCK RENI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Reni",
+        "pincode": 301409,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "8abfe9d5-0a30-4fc0-8fc6-985de11bcaf0",
+            "date": "08-05-2021",
+            "available_capacity": 8,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 575863,
+        "name": "Mungaska UPHC",
+        "address": "Mungaska Near Old TB Hospital",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "1b40bed4-365d-40be-9bc6-bb1bdf411354",
+            "date": "08-05-2021",
+            "available_capacity": 1,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }, {
+            "session_id": "b04de552-0303-4316-bc01-b591c3ca3947",
+            "date": "09-05-2021",
+            "available_capacity": 99,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-04:00PM"]
+        }, {
+            "session_id": "c77bb04d-bb2b-4222-8d5e-e090fbd0f1a0",
+            "date": "10-05-2021",
+            "available_capacity": 1,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }, {
+            "session_id": "66afc2b1-3382-4b14-8e0e-beeac6d07698",
+            "date": "11-05-2021",
+            "available_capacity": 1,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }, {
+            "session_id": "639d9f9e-874a-439b-858e-22ce3ae5845b",
+            "date": "12-05-2021",
+            "available_capacity": 22,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 338820,
+        "name": "45 MUNDAWARA THANAGAZI",
+        "address": "45 MUNDAWARA THANAGAZI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Thanagazi",
+        "pincode": 301024,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "e67a3e32-be37-4a04-9f43-985058dbf24e",
+            "date": "08-05-2021",
+            "available_capacity": 97,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 573279,
+        "name": "Phc Hamirpur Bansur",
+        "address": "Phc Hamirpur",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Bansur",
+        "pincode": 301402,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "32af7895-8f74-4ea7-88df-3e308df36324",
+            "date": "08-05-2021",
+            "available_capacity": 42,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 629855,
+        "name": "MILITARY HOSPITAL ALWAR",
+        "address": "(For Ex-Army And Dependent Only) BUS STAND ALWAR",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "02e40afc-e2fe-4e21-a758-8ccb33f6504c",
+            "date": "08-05-2021",
+            "available_capacity": 41,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 532549,
+        "name": "45PHC BALDEVGARH BLOCK RAJGARH",
+        "address": "PHC BALDEVGARH",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Rajgarh",
+        "pincode": 301410,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "55322822-3f69-49e1-ba77-a847aba9d1f2",
+            "date": "08-05-2021",
+            "available_capacity": 50,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 335103,
+        "name": "45 CHC PRATAPGARH",
+        "address": "CHC PRATAPGARH THANAGAZI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Thanagazi",
+        "pincode": 301027,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "fa3e8325-d466-4ed4-84b8-b28903b1e9dd",
+            "date": "08-05-2021",
+            "available_capacity": 48,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 615225,
+        "name": "45 PHC PADA BLOCK RENI",
+        "address": "PHC PADA BLOCK RENI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Reni",
+        "pincode": 301408,
+        "lat": 0,
+        "long": 0,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "e1b8a259-107a-40d5-a136-a3126ffce365",
+            "date": "08-05-2021",
+            "available_capacity": 10,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 694622,
+        "name": "Rath International School Alwa",
+        "address": "Rath International School Alwar Rath Nagar",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "aa9f4022-632e-4ce4-87c1-f3d5a512788c",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 338838,
+        "name": "45 GHARI PHC THANAGAZI",
+        "address": "45 GHARI PHC",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Thanagazi",
+        "pincode": 301024,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "ade04ad9-2ad2-4b75-b067-0e82e2b04af9",
+            "date": "08-05-2021",
+            "available_capacity": 50,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 663935,
+        "name": "45 PHC KELPURKHERA BLOCK RENI",
+        "address": "PHC KELPURKHERA NEAR ATAL SEVA KENDRA",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Reni",
+        "pincode": 301409,
+        "lat": 0,
+        "long": 0,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "9f54eec6-72cf-4663-bb71-68e3c729096f",
+            "date": "08-05-2021",
+            "available_capacity": 10,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 561457,
+        "name": "District Hospital Above 45",
+        "address": "Rajeev Gandhi District Hospital",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "d60c5e75-dba7-4507-8d7b-0f720e7b521f",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 582338,
+        "name": "District Hospital 18-44",
+        "address": "Rajiv Gandhi District Hospital",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "ALWAR",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "e72a1fdd-e1ff-45bc-8674-d08426bb5968",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 551513,
+        "name": "UPHC NEB Above 45",
+        "address": "N.E.B Alwar",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "98825b93-3a38-472b-8656-e91068fd9b83",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }, {
+            "session_id": "2f5b8d23-466c-48b2-be58-aa6e3621c0cc",
+            "date": "09-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }, {
+            "session_id": "a44a591d-b5b9-4a16-8e5f-1e8a4dee1c1e",
+            "date": "09-05-2021",
+            "available_capacity": 28,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }, {
+            "session_id": "a65355e9-429d-43c0-8296-af70c4fd80a5",
+            "date": "10-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }, {
+            "session_id": "be0fc51a-5fe1-401f-b51b-deebe5cb9ce6",
+            "date": "10-05-2021",
+            "available_capacity": 44,
+            "min_age_limit": 45,
+            "vaccine": "COVAXIN",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 339389,
+        "name": "Nogawa CHC",
+        "address": "Nogawa CHC",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Ramgarh",
+        "pincode": 301026,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "e05756ba-61ef-4441-985c-6597383301eb",
+            "date": "08-05-2021",
+            "available_capacity": 73,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 575106,
+        "name": "45 KOLAHEDA THANAGAZI",
+        "address": "45 Primary Health Center Kolaheda",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Thanagazi",
+        "pincode": 301024,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "967012e5-f6b1-488d-9d4b-bab14786ec94",
+            "date": "08-05-2021",
+            "available_capacity": 49,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 338755,
+        "name": "45 CHC GADISAWAIRAM BLOCK RENI",
+        "address": "CHC GADISAWAIRAM BLOCK RENI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Reni",
+        "pincode": 301409,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "76b8ac2b-660b-47f2-bce8-b27cd9f2ea5c",
+            "date": "08-05-2021",
+            "available_capacity": 6,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 624365,
+        "name": "45 CHC DHARAMSHALA THANAGAZI",
+        "address": "GOVT SCHOOL BLOCK THANAGAZI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Thanagazi",
+        "pincode": 301022,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "d1672526-2f5d-4aa8-8e70-713d0dd6e5fb",
+            "date": "08-05-2021",
+            "available_capacity": 67,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 532093,
+        "name": "Harsoli CHC Kotkasim",
+        "address": "Harsoli CHC",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "baheror",
+        "pincode": 301702,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "890dd6cb-4e23-4b0a-b11b-7358d9f389f0",
+            "date": "08-05-2021",
+            "available_capacity": 27,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 573389,
+        "name": "RAMPUR CHC Bansur",
+        "address": "CHC RAMPUR",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Bansur",
+        "pincode": 301416,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "f521e87c-1e16-43b9-b214-591f4aa2a720",
+            "date": "08-05-2021",
+            "available_capacity": 49,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 532077,
+        "name": "Patan Ahir Sc Bibirani Chc Kot",
+        "address": "Patan Ahir",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "baheror",
+        "pincode": 301702,
+        "lat": 0,
+        "long": 0,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "0939d2c6-2612-49b8-b181-6617b653b267",
+            "date": "08-05-2021",
+            "available_capacity": 34,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 696587,
+        "name": "Step By Step School Alwar",
+        "address": "Step By Step School Alwar",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 27,
+        "long": 76,
+        "from": "13:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "9f64c37a-e962-4cb3-874a-93c54cc40a96",
+            "date": "08-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["01:00PM-02:00PM", "02:00PM-03:00PM", "03:00PM-04:00PM", "04:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 632097,
+        "name": "Chc Khaidli 1 Block Kherli",
+        "address": "KHERLI CHC BLOCK KHERLI",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Kherli",
+        "pincode": 321606,
+        "lat": 27,
+        "long": 77,
+        "from": "08:00:00",
+        "to": "17:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "26a431a7-5a5c-4956-8590-4954266fbb30",
+            "date": "10-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 18,
+            "vaccine": "COVISHIELD",
+            "slots": ["08:00AM-10:00AM", "10:00AM-12:00PM", "12:00PM-02:00PM", "02:00PM-05:00PM"]
+        }]
+    }, {
+        "center_id": 679331,
+        "name": "Sourkha Kala Jindolli Mundawar",
+        "address": "Sourkha Kala",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Mundawar",
+        "pincode": 301404,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "f2426f4b-dc31-46c6-9caf-9b68974b9330",
+            "date": "10-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 578057,
+        "name": "ESIC MEDICAL COLLEGE ALWAR",
+        "address": "MIA ALWAR",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Alwar Urban",
+        "pincode": 301001,
+        "lat": 0,
+        "long": 0,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "e66532ac-e361-4238-8630-3cfb255e8c59",
+            "date": "10-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }, {
+        "center_id": 679310,
+        "name": "SC KALUKA PHC KARNIKOT MUN",
+        "address": "SC KAULKA",
+        "state_name": "Rajasthan",
+        "district_name": "Alwar",
+        "block_name": "Mundawar",
+        "pincode": 301427,
+        "lat": 27,
+        "long": 76,
+        "from": "09:00:00",
+        "to": "18:00:00",
+        "fee_type": "Free",
+        "sessions": [{
+            "session_id": "8c1372e4-5f1e-425b-b7fc-cadc5e9d93bb",
+            "date": "10-05-2021",
+            "available_capacity": 0,
+            "min_age_limit": 45,
+            "vaccine": "COVISHIELD",
+            "slots": ["09:00AM-11:00AM", "11:00AM-01:00PM", "01:00PM-03:00PM", "03:00PM-06:00PM"]
+        }]
+    }]
+}

--- a/tests/sample_response_for_testing.json
+++ b/tests/sample_response_for_testing.json
@@ -1,5 +1,3 @@
-// https://cdn-api.co-vin.in/api/v2/appointment/sessions/public/calendarByDistrict?district_id=512&date=08-05-2021
-// data obtained at around 1800 hrs on 08-05-2021
 {
     "centers": [{
         "center_id": 551487,

--- a/tests/sample_response_for_testing_info.md
+++ b/tests/sample_response_for_testing_info.md
@@ -1,0 +1,2 @@
+https://cdn-api.co-vin.in/api/v2/appointment/sessions/public/calendarByDistrict?district_id=512&date=08-05-2021
+data obtained at around 1800 hrs on 08-05-2021

--- a/tests/test_cowin.py
+++ b/tests/test_cowin.py
@@ -1,5 +1,13 @@
-from cowin_api import CoWinAPI
+import json
+import os
 
+from cowin_api import CoWinAPI
+from cowin_api.utils import filter_centers
+
+def get_data():
+    with open(os.path.join('tests', 'sample_response_for_testing.json'), 'r') as f:
+        data = json.load(f)
+    return data
 
 def test_get_states():
     cowin = CoWinAPI()
@@ -34,8 +42,35 @@ def test_get_availability_by_pincode():
 
 
 def test_min_age_limit_filter():
-    cowin = CoWinAPI()
-    availability = cowin.get_availability_by_district("395", date="03-05-2021", min_age_limt=18)
+    availability = filter_centers(get_data(), ['min_age_limit'], [18])
 
     assert isinstance(availability, dict)
     assert isinstance(availability.get('centers'), list)
+    assert len(availability.get('centers')) == 1
+
+
+def test_vaccine_filter():
+    availability = filter_centers(get_data(), ['vaccine'], ['COVAXIN'])
+
+    assert isinstance(availability, dict)
+    assert isinstance(availability.get('centers'), list)
+    assert sum([len(center.get('sessions')) \
+                for center in availability.get('centers')]) == 10
+
+
+def test_availability_filter():
+    availability = filter_centers(get_data(), ['available_capacity'], [1])
+
+    assert isinstance(availability, dict)
+    assert isinstance(availability.get('centers'), list)
+    assert sum([len(center.get('sessions')) \
+                for center in availability.get('centers')]) == 37
+
+def test_multiple_filter():
+    availability = filter_centers(get_data(), ['vaccine', 'available_capacity'],
+                                        ['COVAXIN', 1])
+
+    assert isinstance(availability, dict)
+    assert isinstance(availability.get('centers'), list)
+    assert sum([len(center.get('sessions')) \
+                for center in availability.get('centers')]) == 7

--- a/tests/test_cowin.py
+++ b/tests/test_cowin.py
@@ -42,7 +42,7 @@ def test_get_availability_by_pincode():
 
 
 def test_min_age_limit_filter():
-    availability = filter_centers(get_data(), ['min_age_limit'], [18])
+    availability = filter_centers(get_data(), {'min_age_limit': 18})
 
     assert isinstance(availability, dict)
     assert isinstance(availability.get('centers'), list)
@@ -50,7 +50,7 @@ def test_min_age_limit_filter():
 
 
 def test_vaccine_filter():
-    availability = filter_centers(get_data(), ['vaccine'], ['COVAXIN'])
+    availability = filter_centers(get_data(), {'vaccine': 'COVAXIN'})
 
     assert isinstance(availability, dict)
     assert isinstance(availability.get('centers'), list)
@@ -59,7 +59,7 @@ def test_vaccine_filter():
 
 
 def test_availability_filter():
-    availability = filter_centers(get_data(), ['available_capacity'], [1])
+    availability = filter_centers(get_data(), {'available_capacity': 1})
 
     assert isinstance(availability, dict)
     assert isinstance(availability.get('centers'), list)
@@ -68,7 +68,7 @@ def test_availability_filter():
 
 
 def test_fee_type_filter():
-    availability = filter_centers(get_data(), ['fee_type'], ['Paid'])
+    availability = filter_centers(get_data(), {'fee_type': 'Paid'})
 
     assert isinstance(availability, dict)
     assert isinstance(availability.get('centers'), list)
@@ -76,7 +76,7 @@ def test_fee_type_filter():
 
 
 def test_fee_type_filter_2():
-    availability = filter_centers(get_data(), ['fee_type'], ['Free'])
+    availability = filter_centers(get_data(), {'fee_type': 'Free'})
 
     assert isinstance(availability, dict)
     assert isinstance(availability.get('centers'), list)
@@ -84,8 +84,9 @@ def test_fee_type_filter_2():
 
 
 def test_multiple_filter():
-    availability = filter_centers(get_data(), ['vaccine', 'available_capacity'],
-                                        ['COVAXIN', 1])
+    availability = filter_centers(get_data(),
+                                 {'vaccine': 'COVAXIN',
+                                  'available_capacity': 1})
 
     assert isinstance(availability, dict)
     assert isinstance(availability.get('centers'), list)

--- a/tests/test_cowin.py
+++ b/tests/test_cowin.py
@@ -92,3 +92,14 @@ def test_multiple_filter():
     assert isinstance(availability.get('centers'), list)
     assert sum([len(center.get('sessions')) \
                 for center in availability.get('centers')]) == 7
+
+
+def test_multiple_filter_2():
+    availability = filter_centers(get_data(),
+                                 {'vaccine': ['COVAXIN', 'COVISHIELD'],
+                                  'available_capacity': 5})
+
+    assert isinstance(availability, dict)
+    assert isinstance(availability.get('centers'), list)
+    assert sum([len(center.get('sessions')) \
+                for center in availability.get('centers')]) == 32

--- a/tests/test_cowin.py
+++ b/tests/test_cowin.py
@@ -66,6 +66,23 @@ def test_availability_filter():
     assert sum([len(center.get('sessions')) \
                 for center in availability.get('centers')]) == 37
 
+
+def test_fee_type_filter():
+    availability = filter_centers(get_data(), ['fee_type'], ['Paid'])
+
+    assert isinstance(availability, dict)
+    assert isinstance(availability.get('centers'), list)
+    assert len(availability.get('centers')) == 0
+
+
+def test_fee_type_filter_2():
+    availability = filter_centers(get_data(), ['fee_type'], ['Free'])
+
+    assert isinstance(availability, dict)
+    assert isinstance(availability.get('centers'), list)
+    assert len(availability.get('centers')) == 47
+
+
 def test_multiple_filter():
     availability = filter_centers(get_data(), ['vaccine', 'available_capacity'],
                                         ['COVAXIN', 1])


### PR DESCRIPTION
…updated tests isolated from api calls

all tests passed, except the first two `test_get_states` and `test_get_districts`. I manually tried to run the urls in the browser and get the similar `{"message":"Forbidden"}` error.

Please have a look at the function [`filter_centers`](https://github.com/DragonWarrior15/cowin/blob/76b88c2e5d01fa56818112ab5f0292633130eaff/cowin_api/utils.py#L12). I might have made it a little difficult to understand and welcome your comments/suggestions to improve the same.

Now the filters available are `min_age_limit`, `min_capacity`, `vaccine`, and `fee_type`.