### PR TITLE
Feature retry

### DIFF
--- a/cowin_api/base_api.py
+++ b/cowin_api/base_api.py
@@ -6,6 +6,8 @@ from requests.exceptions import HTTPError
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
+from cowin_api.constants import Constants
+
 
 class BaseApi:
 
@@ -14,8 +16,8 @@ class BaseApi:
 
         # parameters for retry
         retry_strategy = Retry(
-            total=3,
-            backoff_factor=1, # default is 0 and must be non zero
+            total=Constants.total_retries,
+            backoff_factor=Constants.backoff_factor, # default is 0 and must be non zero
             status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=["GET"]
         )

--- a/cowin_api/base_api.py
+++ b/cowin_api/base_api.py
@@ -3,17 +3,38 @@ from typing import Union
 import requests
 from fake_useragent import UserAgent
 from requests.exceptions import HTTPError
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 
 class BaseApi:
 
     def _call_api(self, url) -> Union[HTTPError, dict]:
         user_agent = UserAgent()
+
+        # parameters for retry
+        retry_strategy = Retry(
+            total=3,
+            backoff_factor=1, # default is 0 and must be non zero
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET"]
+        )
+
+        adapter = HTTPAdapter(max_retries=retry_strategy)
+        http = requests.Session()
+        http.mount("https://", adapter)
+        http.mount("http://", adapter)
+
         headers = {'User-Agent': user_agent.random}
-        response = requests.get(url, headers=headers)
+        response = http.get(url, headers=headers)
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            return e
+            # return an empty dictionary for consistency downstream
+            print(f'[ERROR] {e}')
+            return {}
+        except e:
+            print(f'[ERROR] {e}')
+            return {}
 
         return response.json()

--- a/cowin_api/constants.py
+++ b/cowin_api/constants.py
@@ -8,3 +8,6 @@ class Constants:
     availability_by_district_url = f"{base_url}/appointment/sessions/public/calendarByDistrict"
 
     DD_MM_YYYY = "%d-%m-%Y"
+
+    total_retries = 3
+    backoff_factor = 1

--- a/tests/test_cowin.py
+++ b/tests/test_cowin.py
@@ -35,7 +35,8 @@ def test_get_availability_by_pincode():
 
 def test_min_age_limit_filter():
     cowin = CoWinAPI()
-    availability = cowin.get_availability_by_district("395", date="03-05-2021", min_age_limt=18)
+    # apparently old dates dont work
+    availability = cowin.get_availability_by_district("395", min_age_limt=18)
 
     assert isinstance(availability, dict)
     assert isinstance(availability.get('centers'), list)


### PR DESCRIPTION
* Fix #13 
* Added the `retry` module and updated the `requests` sessions
* Updated the last test dependent on date, apparently the API now gives client error for old dates